### PR TITLE
レビュー後直し1回目

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -42,7 +42,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user.last_name %> <%= @item.user.first_name %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>


### PR DESCRIPTION
# What
商品購入ページの出品者表記
# Why
出品者名の表記がニックネームではなく、本人確認用の名前が表示されていたのでそこを修正。